### PR TITLE
remove unintended fill value #FFF

### DIFF
--- a/packages/react/src/runtime/index.tsx
+++ b/packages/react/src/runtime/index.tsx
@@ -173,9 +173,9 @@ export function IconConverter(id: string, icon: IIconBase, config: IIconConfig):
     switch (theme) {
         case 'outline':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('transparent');
+            colors.push('none');
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('transparent');
+            colors.push('none');
             break;
         case 'filled':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');

--- a/packages/svg/src/runtime/index.tsx
+++ b/packages/svg/src/runtime/index.tsx
@@ -162,9 +162,9 @@ export function IconConverter(id: string, icon: IIconBase, config: IIconConfig):
     switch (theme) {
         case 'outline':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('#FFF');
+            colors.push('none');
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('#FFF');
+            colors.push('none');
             break;
         case 'filled':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');

--- a/packages/vue-next/src/runtime/index.tsx
+++ b/packages/vue-next/src/runtime/index.tsx
@@ -169,9 +169,9 @@ export function IconConverter(id: string, icon: IIconBase, config: IIconConfig):
     switch (theme) {
         case 'outline':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('transparent');
+            colors.push('none');
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('transparent');
+            colors.push('none');
             break;
         case 'filled':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');

--- a/packages/vue/src/runtime/index.tsx
+++ b/packages/vue/src/runtime/index.tsx
@@ -182,9 +182,9 @@ export function IconConverter(id: string, icon: IIconBase, config: IIconConfig):
     switch (theme) {
         case 'outline':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('transparent');
+            colors.push('none');
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');
-            colors.push('transparent');
+            colors.push('none');
             break;
         case 'filled':
             colors.push(typeof fill[0] === 'string' ? fill[0] : 'currentColor');


### PR DESCRIPTION
线性模式下将留白fill值置为none，不用transparent的原因是fill值为transparent复制到Figma中为黑色填充
![image](https://user-images.githubusercontent.com/18344013/97835308-d4b33d80-1d14-11eb-8349-6bd35e34c4c0.png)
