### PR TITLE
feat: add tree-shaking support

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,5 +36,6 @@
     },
     "publishConfig": {
         "access": "public"
-    }
+    },
+    "sideEffects": ["styles/**"]
 }

--- a/packages/svg/package.json
+++ b/packages/svg/package.json
@@ -30,5 +30,6 @@
     },
     "publishConfig": {
         "access": "public"
-    }
+    },
+    "sideEffects": ["styles/**"]
 }

--- a/packages/vue-next/package.json
+++ b/packages/vue-next/package.json
@@ -35,5 +35,6 @@
     },
     "publishConfig": {
         "access": "public"
-    }
+    },
+    "sideEffects": ["styles/**"]
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -39,5 +39,6 @@
     },
     "publishConfig": {
         "access": "public"
-    }
+    },
+    "sideEffects": ["styles/**"]
 }


### PR DESCRIPTION
支持基于 ES Module 的 tree-shaking，对于 Webpack 4 以及 rollup 用户不再需要 `babel-plugin-import` 即可按需加载。