### PR TITLE
fix(vue-next): convert props.type to PascalCase

### DIFF
--- a/packages/vue-next/src/all.ts
+++ b/packages/vue-next/src/all.ts
@@ -21,9 +21,11 @@ const IconParkOptions: IIconAllOptions = {
     name: 'icon-park',
     props: ['size', 'strokeWidth', 'strokeLinecap', 'strokeLinejoin', 'theme', 'fill', 'spin', 'type'],
     setup: (props => {
-
+        const toPascalCase = (val: string) => {
+            return val.replace(/(^\w|-\w)/g, (c: string) => c.replace(/-/, '').toUpperCase());
+        }
+        const type = toPascalCase(props.type);
         const {
-            type,
             theme,
             size,
             fill,


### PR DESCRIPTION
```html
<IconPark type="dark-mode" :theme="iconTheme" />
```

![image](https://user-images.githubusercontent.com/50797685/107474366-31908080-6bad-11eb-99be-f6d6fb9da284.png)

kebab-case to PascalCase
就可以直接用官网上的icon名字了

btw: 官网上的复制到剪贴板 默认只复制名字可好？