### PR TITLE
feat: 添加唯一 id 生成参数的覆盖逻辑

### DIFF
--- a/packages/react/src/runtime/index.tsx
+++ b/packages/react/src/runtime/index.tsx
@@ -86,6 +86,9 @@ export interface IIconConfig {
             innerFillColor: string;
         };
     };
+
+    // 唯一ID 生成函数
+    guid?: () => string,
 }
 
 // 图标基础属性
@@ -232,7 +235,10 @@ export function IconWrapper(name: string, rtl: boolean, render: IconRender): Ico
 
         const ICON_CONFIGS = useContext(IconContext);
 
-        const id = useMemo(guid, []);
+        let id = guid();
+        if (ICON_CONFIGS.guid && typeof ICON_CONFIGS.guid == 'function') {
+            id = ICON_CONFIGS.guid();
+        }
 
         const svgProps = IconConverter(id, {
             size,

--- a/packages/vue-next/src/runtime/index.tsx
+++ b/packages/vue-next/src/runtime/index.tsx
@@ -85,6 +85,9 @@ export interface IIconConfig {
             innerFillColor: string;
         };
     };
+
+    // 唯一ID 生成函数
+    guid?: () => string,
 }
 
 // 图标基础属性
@@ -218,9 +221,12 @@ export function IconWrapper(name: string, rtl: boolean, render: IconRender): Ico
         props: ['size', 'strokeWidth', 'strokeLinecap', 'strokeLinejoin', 'theme', 'fill', 'spin'],
         setup: (props) => {
 
-            const id = guid();
-
             const ICON_CONFIGS = inject(IconContext, DEFAULT_ICON_CONFIGS);
+
+            let id = guid();
+            if (ICON_CONFIGS.guid && typeof ICON_CONFIGS.guid == 'function') {
+                id = ICON_CONFIGS.guid();
+            }
 
             return () => {
 


### PR DESCRIPTION
默认的逻辑在 Recat SSR 环境下生成的 ID 与 浏览器端不一致。